### PR TITLE
Upgrade tomcat and jdk

### DIFF
--- a/java11/Dockerfile
+++ b/java11/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-alpine
 
 ARG EXPOSE_PORT=8080
 EXPOSE ${EXPOSE_PORT}
@@ -19,9 +19,8 @@ LABEL io.k8s.description="Platform for running plain Java applications (fat-jar 
       com.yunify.dev-mode.port="JAVA_DEBUG_PORT:5005"
 
 #Install package
-RUN apt update && apt -y install \
-      fontconfig \
-      && rm -rf /var/lib/apt/list/*
+RUN apk upgrade && apk add --update --no-cache ttf-dejavu fontconfig \
+    && fc-cache --force
 
 # S2I scripts + README
 COPY s2i /usr/local/s2i

--- a/java8/Dockerfile
+++ b/java8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 ARG EXPOSE_PORT=8080
 EXPOSE ${EXPOSE_PORT}

--- a/tomcat85-java11/Dockerfile
+++ b/tomcat85-java11/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-alpine
 
 
 MAINTAINER kubesphere@yunify.com
@@ -20,14 +20,13 @@ LABEL io.kubesphere.s2i.version.maven="3.5.4" \
 
 EXPOSE 8080
 
-ENV TOMCAT_VERSION 8.5.32
+ENV TOMCAT_VERSION 8.5.92
 
 USER root
 
 #Install package
-RUN apt update && apt -y install \
-      fontconfig \
-      && rm -rf /var/lib/apt/list/*
+RUN apk upgrade && apk add --update --no-cache ttf-dejavu fontconfig \
+    && fc-cache --force
 
 # Get and Unpack Tomcat
 RUN apt-get update \

--- a/tomcat85-java8/Dockerfile
+++ b/tomcat85-java8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 
 MAINTAINER kubesphere@yunify.com
@@ -20,7 +20,7 @@ LABEL io.kubesphere.s2i.version.maven="3.5.4" \
 
 EXPOSE 8080
 
-ENV TOMCAT_VERSION 8.5.32
+ENV TOMCAT_VERSION 8.5.92
 
 USER root
 


### PR DESCRIPTION
1. Fixes security vulnerabilities in older versions.

- **old version**
```
$ trivy image kubesphere/java8-runtime:v3.2.0 --skip-db-update
2023-08-22T02:27:39.470-0400    INFO    Vulnerability scanning is enabled
2023-08-22T02:27:39.470-0400    INFO    Secret scanning is enabled
2023-08-22T02:27:39.470-0400    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-08-22T02:27:39.470-0400    INFO    Please see also https://aquasecurity.github.io/trivy/v0.44/docs/scanner/secret/#recommendation for faster secret detection
2023-08-22T02:27:41.678-0400    INFO    Detected OS: alpine
2023-08-22T02:27:41.678-0400    INFO    Detecting Alpine vulnerabilities...
2023-08-22T02:27:41.711-0400    INFO    Number of language-specific files: 0
2023-08-22T02:27:41.772-0400    WARN    This OS version is no longer supported by the distribution: alpine 3.9.4
2023-08-22T02:27:41.773-0400    WARN    The vulnerability detection may be insufficient because security updates are not provided

kubesphere/java8-runtime:v3.2.0 (alpine 3.9.4)

Total: 274 (UNKNOWN: 0, LOW: 140, MEDIUM: 98, HIGH: 32, CRITICAL: 4)
```

- **new version**
```
$ trivy image kubesphere/java8-runtime:v3.2.0-new --skip-db-update
2023-08-22T02:40:43.293-0400    INFO    Vulnerability scanning is enabled
2023-08-22T02:40:43.293-0400    INFO    Secret scanning is enabled
2023-08-22T02:40:43.293-0400    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-08-22T02:40:43.293-0400    INFO    Please see also https://aquasecurity.github.io/trivy/v0.44/docs/scanner/secret/#recommendation for faster secret detection
2023-08-22T02:40:52.152-0400    INFO    JAR files found
2023-08-22T02:40:52.210-0400    INFO    Analyzing JAR files takes a while...
2023-08-22T02:40:52.416-0400    INFO    Detected OS: alpine
2023-08-22T02:40:52.416-0400    INFO    Detecting Alpine vulnerabilities...
2023-08-22T02:40:52.441-0400    INFO    Number of language-specific files: 0

kubesphere/java8-runtime:v3.2.0-new (alpine 3.18.3)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

2. Bump tomcat from 8.5.32 to 8.5.92.